### PR TITLE
Derive user automatically or prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ You can also specify a config file as a CLI arg:
 weep --config somethingdifferent.yaml list
 ```
 
+Weep supports authenticating to ConsoleMe in either a standalone challenge mode (ConsoleMe will authenticate the user
+according to its settings), or mutual TLS (ConsoleMe has to be configured to accept mutual TLS).
+
+In challenge mode, Weep will prompt the user for their username the first time they authenticate, and then attempt to
+derive their username from their valid/expired jwt on subsequent attempts. You can also specify the desired username
+in weep's configuration under the `challenge_settings.user` setting as seen in  `example-config.yaml`.
 
 
 ## Routing traffic

--- a/challenge/types.go
+++ b/challenge/types.go
@@ -29,4 +29,5 @@ type ConsolemeChallengeResponse struct {
 	WantHttpOnly bool   `json:"http_only"`
 	SameSite     int    `json:"same_site"`
 	Expires      int64  `json:"expiration"`
+	User         string `json:"user"`
 }

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,7 +1,7 @@
 consoleme_url: https://path_to_consoleme:port
 authentication_method: mtls # challenge or mtls
-challenge_settings: # only needed if authentication_method is challenge
-  user: you@example.com
+#challenge_settings: # (Optional) Username can be provided. If it is not provided, user will be prompted on first authentication attempt
+#  user: you@example.com
 mtls_settings: # only needed if authentication_method is mtls
   cert: mtls.crt
   key: mtls.key


### PR DESCRIPTION
This PR makes specifying the username in Weep's configuration optional.

On first run, Weep will prompt the user for their username if it is not in the configuration.
On subsequent runs, Weep will attempt to derive the username from the valid (or expired) credential jwt that weep has previously saved.