### PR TITLE
Let users assume role after retrieving creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ weep metadata arn:aws:iam::123456789012:role/exampleRole
 
 # ...or just the role name
 weep metadata exampleRole
+
+# And you can assume a role
+weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole
+
+# ...or a whole bunch of roles
+weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole -A arn:aws:iam::123456789012:role/andAnother -A arn:aws:iam::123456789012:role/andOneMore
 ```
 
 run `aws sts get-caller-identity` to confirm that your DNAT rules are correctly configured.
@@ -84,6 +90,9 @@ eval $(weep export arn:aws:iam::123456789012:role/fullOrPartialRoleName)
 
 # this one also works with just the role name!
 eval $(weep export fullOrPartialRoleName)
+
+# and with one or more role assumptions
+eval $(weep export fullOrPartialRoleName -A arn:aws:iam::123456789012:role/roleToAssume)
 ```
 
 Then run `aws sts get-caller-identity` to confirm that your credentials work properly.
@@ -99,6 +108,9 @@ weep file exampleRole
 # you can also specify a profile name
 weep file stagingRole --profile staging
 weep file prodRole --profile prod
+
+# and a role to assume
+weep file stagingRole -A arn:aws:iam::123456789012:role/otherRole --profile staging
 
 # don't prompt before overwriting existing creds
 weep file prodRole --profile prod -f
@@ -144,6 +156,26 @@ ECS credential provider to avoid this issue.
 # the rate of your AWS API calls.
 weep generate_credential_process_config
 ```
+
+## Assuming Roles
+
+For commands that support assuming a role, pass the `-A` flag with a role ARN. You can
+do this as many times as you'd like and the roles will be assumed in the order passed in.
+
+> **Note**: You must provide the whole ARN for the role(s) to be assumed
+
+```bash
+# Assume otherRole using credentials from exampleRole
+weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole
+
+# Assume otherRole then assume andAnother
+weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole -A arn:aws:iam::123456789012:role/andAnother
+
+# Roles to assume can also be passed as a comma-separated list. This will do the same thing as the previous example
+weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole,arn:aws:iam::123456789012:role/andAnother
+```
+
+
 ## Shell Completion
 
 ### Bash

--- a/cmd/credential_process.go
+++ b/cmd/credential_process.go
@@ -24,7 +24,7 @@ import (
 	"github.com/netflix/weep/util"
 	ini "gopkg.in/ini.v1"
 
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -80,7 +80,7 @@ func writeConfigFile(roles []string) error {
 }
 
 func runGenerateCredentialProcessConfig(cmd *cobra.Command, args []string) error {
-	client, err := consoleme.GetClient()
+	client, err := creds.GetClient()
 	if err != nil {
 		return err
 	}
@@ -97,26 +97,22 @@ func runGenerateCredentialProcessConfig(cmd *cobra.Command, args []string) error
 
 func runCredentialProcess(cmd *cobra.Command, args []string) error {
 	role = args[0]
-	client, err := consoleme.GetClient()
+	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole...)
 	if err != nil {
 		return err
 	}
-	creds, err := client.GetRoleCredentials(role, noIpRestrict)
-	if err != nil {
-		return err
-	}
-	printCredentialProcess(creds)
+	printCredentialProcess(credentials)
 	return nil
 }
 
-func printCredentialProcess(creds consoleme.AwsCredentials) {
-	expirationTimeFormat := time.Unix(creds.Expiration, 0).Format(time.RFC3339)
+func printCredentialProcess(credentials *creds.AwsCredentials) {
+	expirationTimeFormat := time.Unix(credentials.Expiration, 0).Format(time.RFC3339)
 
-	credentialProcessOutput := &consoleme.CredentialProcess{
+	credentialProcessOutput := &creds.CredentialProcess{
 		Version:         1,
-		AccessKeyId:     creds.AccessKeyId,
-		SecretAccessKey: creds.SecretAccessKey,
-		SessionToken:    creds.SessionToken,
+		AccessKeyId:     credentials.AccessKeyId,
+		SecretAccessKey: credentials.SecretAccessKey,
+		SessionToken:    credentials.SessionToken,
 		Expiration:      expirationTimeFormat,
 	}
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 	"github.com/spf13/cobra"
 )
 
@@ -39,11 +39,7 @@ var exportCmd = &cobra.Command{
 
 func runExport(cmd *cobra.Command, args []string) error {
 	role = args[0]
-	client, err := consoleme.GetClient()
-	if err != nil {
-		return err
-	}
-	creds, err := client.GetRoleCredentials(role, noIpRestrict)
+	creds, err := creds.GetCredentials(role, noIpRestrict, assumeRole...)
 	if err != nil {
 		return err
 	}
@@ -62,7 +58,7 @@ func isFish() bool {
 	}
 }
 
-func printExport(creds consoleme.AwsCredentials) {
+func printExport(creds *creds.AwsCredentials) {
 	if isFish() {
 		// fish has a different way of setting variables than bash/zsh and others
 		fmt.Printf("set -x AWS_ACCESS_KEY_ID %s && set -x AWS_SECRET_ACCESS_KEY %s && set -x AWS_SESSION_TOKEN %s\n",

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -24,7 +24,7 @@ import (
 	ini "gopkg.in/ini.v1"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 	"github.com/netflix/weep/util"
 	"github.com/spf13/cobra"
 )
@@ -46,11 +46,7 @@ var fileCmd = &cobra.Command{
 
 func runFile(cmd *cobra.Command, args []string) error {
 	role = args[0]
-	client, err := consoleme.GetClient()
-	if err != nil {
-		return err
-	}
-	credentials, err := client.GetRoleCredentials(role, noIpRestrict)
+	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole...)
 	if err != nil {
 		return err
 	}
@@ -90,7 +86,7 @@ func shouldOverwriteCredentials() bool {
 	return userForce
 }
 
-func writeCredentialsFile(credentials consoleme.AwsCredentials) error {
+func writeCredentialsFile(credentials *creds.AwsCredentials) error {
 	var credentialsINI *ini.File
 	var err error
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +34,7 @@ var listCmd = &cobra.Command{
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	client, err := consoleme.GetClient()
+	client, err := creds.GetClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/gorilla/mux"
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 	"github.com/netflix/weep/handlers"
 	"github.com/netflix/weep/metadata"
 	log "github.com/sirupsen/logrus"
@@ -52,7 +52,7 @@ func runMetadata(cmd *cobra.Command, args []string) error {
 	role = args[0]
 	metadata.Role = role
 	metadata.MetadataRegion = metadataRegion
-	client, err := consoleme.GetClient()
+	client, err := creds.GetClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,8 +48,9 @@ func init() {
 	cobra.OnInitialize(initLogging)
 
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.weep.yaml)")
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "log-format", "", "log format (json or tty)")
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "log-level", "", "log level (debug, info, warn)")
+	rootCmd.PersistentFlags().StringSliceVarP(&assumeRole, "assume-role", "A", make([]string, 0), "one or more roles to assume after retrieving credentials")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "", "log format (json or tty)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level (debug, info, warn)")
 
 }
 

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -17,6 +17,7 @@
 package cmd
 
 var (
+	assumeRole         []string
 	role               string
 	profileName        string
 	destination        string

--- a/creds/aws.go
+++ b/creds/aws.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package creds
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+func getAwsCredentials(role string, ipRestrict bool) (string, string, string, error) {
+	client, err := GetClient()
+	if err != nil {
+		return "", "", "", err
+	}
+	tempCreds, err := client.GetRoleCredentials(role, ipRestrict)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return tempCreds.AccessKeyId, tempCreds.SecretAccessKey, tempCreds.SessionToken, nil
+}
+
+func getAssumeRoleCredentials(id, secret, token, roleArn string) (string, string, string, error) {
+	staticCreds := credentials.NewStaticCredentials(id, secret, token)
+	awsSession := session.Must(session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Credentials: staticCreds,
+		},
+	}))
+
+	stsSession := sts.New(awsSession)
+
+	stsParams := &sts.AssumeRoleInput{
+		RoleArn:         &roleArn,
+		RoleSessionName: aws.String("weep"),
+		DurationSeconds: aws.Int64(3600),
+	}
+
+	stsCreds, err := stsSession.AssumeRole(stsParams)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error retrieving awsSession token: %s", err)
+	}
+	return *stsCreds.Credentials.AccessKeyId, *stsCreds.Credentials.SecretAccessKey, *stsCreds.Credentials.SessionToken, nil
+}
+
+func GetCredentials(role string, ipRestrict bool, assumeRole ...string) (*AwsCredentials, error) {
+	id, secret, token, err := getAwsCredentials(role, ipRestrict)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, assumeRoleArn := range assumeRole {
+		id, secret, token, err = getAssumeRoleCredentials(id, secret, token, assumeRoleArn)
+		if err != nil {
+			return nil, fmt.Errorf("role assumption failed for %s: %s", assumeRoleArn, err)
+		}
+	}
+
+	finalCreds := &AwsCredentials{
+		AccessKeyId:     id,
+		SecretAccessKey: secret,
+		SessionToken:    token,
+	}
+	return finalCreds, nil
+}

--- a/creds/consoleme.go
+++ b/creds/consoleme.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package consoleme
+package creds
 
 import (
 	"bytes"

--- a/creds/types.go
+++ b/creds/types.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package consoleme
+package creds
 
 type AwsCredentials struct {
 	AccessKeyId     string `json:"AccessKeyId"`

--- a/handlers/ecsCredentialsHandler.go
+++ b/handlers/ecsCredentialsHandler.go
@@ -24,22 +24,22 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 	"github.com/netflix/weep/metadata"
 	log "github.com/sirupsen/logrus"
 )
 
-var credentialMap = make(map[string]consoleme.AwsCredentials)
+var credentialMap = make(map[string]creds.AwsCredentials)
 
 func ECSMetadataServiceCredentialsHandler(w http.ResponseWriter, r *http.Request) {
-	var client, err = consoleme.GetClient()
+	var client, err = creds.GetClient()
 	if err != nil {
 		log.Error(err)
 		return
 	}
 	vars := mux.Vars(r)
 	requestedRole := vars["role"]
-	var Credentials consoleme.AwsCredentials
+	var Credentials creds.AwsCredentials
 
 	val, ok := credentialMap[requestedRole]
 	if ok {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -22,18 +22,18 @@ import (
 	"github.com/netflix/weep/util"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/netflix/weep/consoleme"
+	"github.com/netflix/weep/creds"
 )
 
 var (
 	Role                string
 	NoIpRestrict        bool
-	MetaDataCredentials consoleme.AwsCredentials
+	MetaDataCredentials creds.AwsCredentials
 	MetadataRegion      string
 	LastRenewal         time.Time
 )
 
-func StartMetaDataRefresh(client *consoleme.Client) {
+func StartMetaDataRefresh(client *creds.Client) {
 	retryDelay := 5 * time.Second
 	retryCount := 10
 	var err error


### PR DESCRIPTION
Allow role assumptions with the `-A` flag for the `metadata`, `file`, and `export` commands. Multiple role ARNs can be specified and will be assumed in the order provided.