### PR TITLE
Add assume role to ECS credential provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole -A arn:aws
 weep metadata exampleRole -A arn:aws:iam::123456789012:role/otherRole,arn:aws:iam::123456789012:role/andAnother
 ```
 
+When using the ECS credential provider, pass the role(s) to be assumed as a comma-separated query-string with the key `assume`:
+
+```bash
+AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost:9091/ecs/consoleme_oss_1?assume=arn:aws:iam::123456789012:role/otherRole,arn:aws:iam::123456789012:role/andAnother aws sts get-caller-identity
+{
+    "UserId": "AROA4JEFLERSKVPFT4INI:user@example.com",
+    "Account": "123456789012",
+    "Arn": "arn:aws:sts::123456789012:assumed-role/andAnother/user@example.com"
+}
+```
 
 ## Shell Completion
 

--- a/cmd/credential_process.go
+++ b/cmd/credential_process.go
@@ -97,7 +97,7 @@ func runGenerateCredentialProcessConfig(cmd *cobra.Command, args []string) error
 
 func runCredentialProcess(cmd *cobra.Command, args []string) error {
 	role = args[0]
-	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole...)
+	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole)
 	if err != nil {
 		return err
 	}

--- a/cmd/ecs_credential_provider.go
+++ b/cmd/ecs_credential_provider.go
@@ -33,8 +33,8 @@ import (
 )
 
 func init() {
-	ecsCredentialProvider.PersistentFlags().StringVarP(&metadataListenAddr, "listen-address", "a", "127.0.0.1", "IP address for the ECS credential provider to listen on")
-	ecsCredentialProvider.PersistentFlags().IntVarP(&metadataListenPort, "port", "p", viper.GetInt("server.ecs_credential_provider_port"), "port for the ECS credential provider service to listen on")
+	ecsCredentialProvider.PersistentFlags().StringVarP(&ecsProviderListenAddr, "listen-address", "a", "127.0.0.1", "IP address for the ECS credential provider to listen on")
+	ecsCredentialProvider.PersistentFlags().IntVarP(&ecsProviderListenPort, "port", "p", viper.GetInt("server.ecs_credential_provider_port"), "port for the ECS credential provider service to listen on")
 	rootCmd.AddCommand(ecsCredentialProvider)
 }
 
@@ -45,14 +45,14 @@ var ecsCredentialProvider = &cobra.Command{
 }
 
 func runEcsMetadata(cmd *cobra.Command, args []string) error {
-	ipaddress := net.ParseIP(metadataListenAddr)
+	ipaddress := net.ParseIP(ecsProviderListenAddr)
 
 	if ipaddress == nil {
-		fmt.Println("Invalid IP: ", metadataListenAddr)
+		fmt.Println("Invalid IP: ", ecsProviderListenAddr)
 		os.Exit(1)
 	}
 
-	listenAddr := fmt.Sprintf("%s:%d", ipaddress, metadataListenPort)
+	listenAddr := fmt.Sprintf("%s:%d", ipaddress, ecsProviderListenPort)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/ecs/{role:.*}", handlers.MetaDataServiceMiddleware(handlers.ECSMetadataServiceCredentialsHandler))

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -39,7 +39,7 @@ var exportCmd = &cobra.Command{
 
 func runExport(cmd *cobra.Command, args []string) error {
 	role = args[0]
-	creds, err := creds.GetCredentials(role, noIpRestrict, assumeRole...)
+	creds, err := creds.GetCredentials(role, noIpRestrict, assumeRole)
 	if err != nil {
 		return err
 	}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -46,7 +46,7 @@ var fileCmd = &cobra.Command{
 
 func runFile(cmd *cobra.Command, args []string) error {
 	role = args[0]
-	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole...)
+	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole)
 	if err != nil {
 		return err
 	}

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -17,17 +17,19 @@
 package cmd
 
 var (
-	assumeRole         []string
-	role               string
-	profileName        string
-	destination        string
-	destinationConfig  string
-	force              bool
-	noIpRestrict       bool
-	metadataRegion     string
-	metadataListenAddr string
-	metadataListenPort int
-	cfgFile            string
-	logLevel           string
-	logFormat          string
+	assumeRole            []string
+	role                  string
+	profileName           string
+	destination           string
+	destinationConfig     string
+	force                 bool
+	noIpRestrict          bool
+	metadataRegion        string
+	metadataListenAddr    string
+	metadataListenPort    int
+	ecsProviderListenAddr string
+	ecsProviderListenPort int
+	cfgFile               string
+	logLevel              string
+	logFormat             string
 )


### PR DESCRIPTION
This PR adds the ability to specify one or more roles to assume when using the ECS credentials handler.