### PR TITLE
Fix CA trust configuration key

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -17,7 +17,7 @@ mtls_settings: # only needed if authentication_method is mtls
   old_cert_message: mTLS certificate is too old, please run [refresh command]
   cert: mtls.crt
   key: mtls.key
-  cafile: mtlsCA.pem
+  catrust: mtlsCA.pem
   insecure: false
   darwin: # weep will look in platform-specific directories for the three files specified above
     - "/run/mtls/certificates"

--- a/util/prompt.go
+++ b/util/prompt.go
@@ -62,7 +62,7 @@ func FirstRunPrompt() error {
 		if err != nil {
 			return err
 		}
-		viper.Set("mtls_settings.cafile", ca)
+		viper.Set("mtls_settings.catrust", ca)
 
 		insecure, err := PromptBool("Skip validation of mTLS hostname?")
 		if err != nil {


### PR DESCRIPTION
Fixes the generated and example configurations for weep, which were using `cafile` instead of `catrust` for the mTLS CA file config key.