### PR TITLE
Add HTTP healthcheck endpoint

### DIFF
--- a/cmd/ecs_credential_provider.go
+++ b/cmd/ecs_credential_provider.go
@@ -51,6 +51,7 @@ func runEcsMetadata(cmd *cobra.Command, args []string) error {
 	listenAddr := fmt.Sprintf("%s:%d", ipaddress, ecsProviderListenPort)
 
 	router := mux.NewRouter()
+	router.HandleFunc("/healthcheck", handlers.HealthcheckHandler)
 	router.HandleFunc("/ecs/{role:.*}", handlers.MetaDataServiceMiddleware(handlers.ECSMetadataServiceCredentialsHandler))
 	router.HandleFunc("/{path:.*}", handlers.MetaDataServiceMiddleware(handlers.CustomHandler))
 

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -65,6 +65,7 @@ func runMetadata(cmd *cobra.Command, args []string) error {
 	listenAddr := fmt.Sprintf("%s:%d", ipaddress, metadataListenPort)
 
 	router := mux.NewRouter()
+	router.HandleFunc("/healthcheck", handlers.HealthcheckHandler)
 	router.HandleFunc("/{version}/", handlers.MetaDataServiceMiddleware(handlers.BaseVersionHandler))
 	router.HandleFunc("/{version}/api/token", handlers.MetaDataServiceMiddleware(handlers.TokenHandler)).Methods("PUT")
 	router.HandleFunc("/{version}/meta-data", handlers.MetaDataServiceMiddleware(handlers.BaseHandler))

--- a/handlers/healthcheckHandler.go
+++ b/handlers/healthcheckHandler.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/netflix/weep/health"
+	log "github.com/sirupsen/logrus"
+)
+
+type healthcheckResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}
+
+func HealthcheckHandler(w http.ResponseWriter, r *http.Request) {
+	healthy, reason := health.WeepStatus.Get()
+	var status int
+	if healthy {
+		status = http.StatusOK
+	} else {
+		status = http.StatusInternalServerError
+	}
+	resp := healthcheckResponse{
+		Status:  status,
+		Message: reason,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		log.Errorf("error writing healthcheck response: %v", err)
+	}
+}

--- a/health/health.go
+++ b/health/health.go
@@ -5,35 +5,34 @@ import "sync"
 var WeepStatus status
 
 type status struct {
+	sync.RWMutex
 	healthy bool
 	reason  string
-	m       *sync.RWMutex
 }
 
 func init() {
 	WeepStatus = status{
 		healthy: true,
 		reason:  "healthy",
-		m:       &sync.RWMutex{},
 	}
 }
 
 func (s *status) Get() (bool, string) {
-	s.m.RLock()
-	defer s.m.RUnlock()
+	s.RLock()
+	defer s.RUnlock()
 	return s.healthy, s.reason
 }
 
 func (s *status) SetUnhealthy(reason string) {
-	s.m.Lock()
-	defer s.m.Unlock()
+	s.Lock()
+	defer s.Unlock()
 	s.healthy = false
 	s.reason = reason
 }
 
 func (s *status) SetHealthy() {
-	s.m.Lock()
-	defer s.m.Unlock()
+	s.Lock()
+	defer s.Unlock()
 	s.healthy = true
 	s.reason = "healthy"
 }

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,32 @@
+package health
+
+import "sync"
+
+var WeepStatus status
+
+type status struct {
+	healthy bool
+	reason  string
+	m       *sync.RWMutex
+}
+
+func init() {
+	WeepStatus = status{
+		healthy: true,
+		reason:  "healthy",
+		m:       &sync.RWMutex{},
+	}
+}
+
+func (s *status) Get() (bool, string) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.healthy, s.reason
+}
+
+func (s *status) Set(healthy bool, reason string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.healthy = healthy
+	s.reason = reason
+}

--- a/health/health.go
+++ b/health/health.go
@@ -24,9 +24,16 @@ func (s *status) Get() (bool, string) {
 	return s.healthy, s.reason
 }
 
-func (s *status) Set(healthy bool, reason string) {
+func (s *status) SetUnhealthy(reason string) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	s.healthy = healthy
+	s.healthy = false
 	s.reason = reason
+}
+
+func (s *status) SetHealthy() {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.healthy = true
+	s.reason = "healthy"
 }


### PR DESCRIPTION
This PR adds the mechanisms for an HTTP healthcheck endpoint. It currently returns `200 OK` no matter what. Handling of unhealthy states will be handled in subsequent PRs.