### PR TITLE
Tweak browser filter denials

### DIFF
--- a/handlers/middleware_test.go
+++ b/handlers/middleware_test.go
@@ -6,68 +6,87 @@ import (
 	"testing"
 )
 
+var browserHeaderTestCases = []struct {
+	Description    string
+	HeaderName     string
+	HeaderValue    string
+	ExpectedStatus int
+}{
+	{
+		Description:    "valid request",
+		HeaderName:     "User-Agent",
+		HeaderValue:    "boto3/foo",
+		ExpectedStatus: http.StatusOK,
+	},
+	{
+		Description:    "Mozilla in user-agent",
+		HeaderName:     "User-Agent",
+		HeaderValue:    "Mozilla",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "mozilla in user-agent",
+		HeaderName:     "User-Agent",
+		HeaderValue:    "mozilla",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "referrer header set",
+		HeaderName:     "Referrer",
+		HeaderValue:    "anything",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "empty referrer header set",
+		HeaderName:     "Referrer",
+		HeaderValue:    "",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "origin header set",
+		HeaderName:     "Origin",
+		HeaderValue:    "anything",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "empty origin header set",
+		HeaderName:     "Origin",
+		HeaderValue:    "",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "host header not in allowlist",
+		HeaderName:     "Host",
+		HeaderValue:    "netflix.com",
+		ExpectedStatus: http.StatusForbidden,
+	},
+	{
+		Description:    "host header in allowlist (127.0.0.1)",
+		HeaderName:     "Host",
+		HeaderValue:    "localhost",
+		ExpectedStatus: http.StatusOK,
+	},
+	{
+		Description:    "host header in allowlist (127.0.0.1)",
+		HeaderName:     "Host",
+		HeaderValue:    "127.0.0.1",
+		ExpectedStatus: http.StatusOK,
+	},
+	{
+		Description:    "host header in allowlist (169.254.169.254)",
+		HeaderName:     "Host",
+		HeaderValue:    "169.254.169.254",
+		ExpectedStatus: http.StatusOK,
+	},
+}
+
 // TestBrowserFilterMiddleware ensures 403 Forbidden is returned for all requests that look like
 // they came from a web browser.
 func TestBrowserFilterMiddleware(t *testing.T) {
-	cases := []struct {
-		Description    string
-		HeaderName     string
-		HeaderValue    string
-		ExpectedStatus int
-	}{
-		{
-			Description:    "valid request",
-			HeaderName:     "User-Agent",
-			HeaderValue:    "boto3/foo",
-			ExpectedStatus: http.StatusOK,
-		},
-		{
-			Description:    "Mozilla in user-agent",
-			HeaderName:     "User-Agent",
-			HeaderValue:    "Mozilla",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "mozilla in user-agent",
-			HeaderName:     "User-Agent",
-			HeaderValue:    "mozilla",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "referrer header set",
-			HeaderName:     "Referrer",
-			HeaderValue:    "anything",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "origin header set",
-			HeaderName:     "Origin",
-			HeaderValue:    "anything",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "host header not in allowlist",
-			HeaderName:     "Host",
-			HeaderValue:    "netflix.com",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "host header in allowlist (127.0.0.1)",
-			HeaderName:     "Host",
-			HeaderValue:    "127.0.0.1",
-			ExpectedStatus: http.StatusOK,
-		},
-		{
-			Description:    "host header in allowlist (169.254.169.254)",
-			HeaderName:     "Host",
-			HeaderValue:    "127.0.0.1",
-			ExpectedStatus: http.StatusOK,
-		},
-	}
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	for i, tc := range cases {
+	for i, tc := range browserHeaderTestCases {
 		t.Logf("test case %d: %s", i, tc.Description)
 		bfmHandler := BrowserFilterMiddleware(nextHandler)
 		req := httptest.NewRequest("GET", "http://localhost", nil)
@@ -112,65 +131,10 @@ func TestAWSHeaderMiddleware(t *testing.T) {
 // TestCredentialServiceMiddleware is a superset of TestBrowserFilterMiddleware and TestAWSHeaderMiddleware
 // since CredentialServiceMiddleware is a chain of BrowserFilterMiddleware and AWSHeaderMiddleware
 func TestCredentialServiceMiddleware(t *testing.T) {
-	cases := []struct {
-		Description    string
-		HeaderName     string
-		HeaderValue    string
-		ExpectedStatus int
-	}{
-		{
-			Description:    "valid request",
-			HeaderName:     "User-Agent",
-			HeaderValue:    "boto3/foo",
-			ExpectedStatus: http.StatusOK,
-		},
-		{
-			Description:    "Mozilla in user-agent",
-			HeaderName:     "User-Agent",
-			HeaderValue:    "Mozilla",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "mozilla in user-agent",
-			HeaderName:     "User-Agent",
-			HeaderValue:    "mozilla",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "referrer header set",
-			HeaderName:     "Referrer",
-			HeaderValue:    "anything",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "origin header set",
-			HeaderName:     "Origin",
-			HeaderValue:    "anything",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "host header not in allowlist",
-			HeaderName:     "Host",
-			HeaderValue:    "netflix.com",
-			ExpectedStatus: http.StatusForbidden,
-		},
-		{
-			Description:    "host header in allowlist (127.0.0.1)",
-			HeaderName:     "Host",
-			HeaderValue:    "127.0.0.1",
-			ExpectedStatus: http.StatusOK,
-		},
-		{
-			Description:    "host header in allowlist (169.254.169.254)",
-			HeaderName:     "Host",
-			HeaderValue:    "127.0.0.1",
-			ExpectedStatus: http.StatusOK,
-		},
-	}
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	for i, tc := range cases {
+	for i, tc := range browserHeaderTestCases {
 		t.Logf("test case %d: %s", i, tc.Description)
 		bfmHandler := CredentialServiceMiddleware(nextHandler)
 		req := httptest.NewRequest("GET", "http://localhost", nil)


### PR DESCRIPTION
- Don't allow an empty host header
- Add `localhost` to allowed hosts
- Deny presence of `Referrer` or `Origin`, even if set to an empty value
- Add test cases for the above and DRY up test file