### PR TITLE
Add release logic for demo site binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,5 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,9 @@ before:
   hooks:
     - go mod download
 builds:
-  - env:
+  -
+    id: default
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -13,9 +15,19 @@ builds:
     ldflags:
       - -s -w -extldflags "-static" -X github.com/netflix/weep/version.Version={{.Version}} -X github.com/netflix/weep/version.Commit={{.CommitDate}} -X github.com/netflix/weep/version.Date={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
-#    hooks:
-#      post:
-#        - upx "{{ .Path }}"
+  -
+    id: demo
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -extldflags "-static" -X github.com/netflix/weep/config.EmbeddedConfigFile=/weep-demo.yaml -X github.com/netflix/weep/version.Version={{.Version}} -X github.com/netflix/weep/version.Commit={{.CommitDate}} -X github.com/netflix/weep/version.Date={{.Date}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
 archives:
   - replacements:
       darwin: Darwin
@@ -35,9 +47,14 @@ changelog:
       - '^test:'
 release:
   prerelease: auto
+  ids:
+    - default
 dockers:
-  - goos: linux
+  -
+    goos: linux
     goarch: amd64
+    ids:
+      - default
     binaries:
       - weep
     image_templates:
@@ -51,3 +68,10 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+blobs:
+  -
+    provider: s3
+    bucket: consolemeoss
+    ids:
+    - demo
+    folder: "consolemeoss_deploy/weep_binaries/{{.Version}}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}/"

--- a/weep-demo.yaml
+++ b/weep-demo.yaml
@@ -1,0 +1,8 @@
+authentication_method: challenge
+consoleme_url: https://demo.consolemeoss.com
+mtls_settings:
+  old_cert_message: mTLS certificate is too old, please refresh mtls certificate
+server:
+  ecs_credential_provider_port: 9091
+  http_timeout: 20
+  metadata_port: 9090

--- a/weep-demo.yaml
+++ b/weep-demo.yaml
@@ -1,3 +1,4 @@
+# Weep configuration for the ConsoleMe OSS demo site
 authentication_method: challenge
 consoleme_url: https://demo.consolemeoss.com
 mtls_settings:


### PR DESCRIPTION
This PR adds a goreleaser build config to compile binaries with a built-in configuration for the [ConsoleMe OSS demo site](https://demo.consolemeoss.com). Resulting binaries are uploaded to an S3 bucket.