### PR TITLE
Reuse TLS config to avoid FD exhaustion

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,12 +20,15 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/netflix/weep/logging"
+
 	"github.com/netflix/weep/creds"
 	"github.com/netflix/weep/errors"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var GlobalCache CredentialCache
+var log = logging.GetLogger()
 
 type CredentialCache struct {
 	sync.RWMutex
@@ -46,7 +49,7 @@ func getCacheSlug(role string, assume []string) string {
 }
 
 func (cc *CredentialCache) Get(role string, assumeChain []string) (*creds.RefreshableProvider, error) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"role":        role,
 		"assumeChain": assumeChain,
 	}).Info("retrieving credentials")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -24,8 +24,8 @@ import (
 )
 
 func init() {
-	serveCmd.PersistentFlags().StringVarP(&listenAddr, "listen-address", "a", "127.0.0.1", "IP address for the ECS credential provider to listen on")
-	serveCmd.PersistentFlags().IntVarP(&listenPort, "port", "p", viper.GetInt("server.ecs_credential_provider_port"), "port for the ECS credential provider service to listen on")
+	serveCmd.PersistentFlags().StringVarP(&listenAddr, "listen-address", "a", viper.GetString("server.address"), "IP address for the ECS credential provider to listen on")
+	serveCmd.PersistentFlags().IntVarP(&listenPort, "port", "p", viper.GetInt("server.port"), "port for the ECS credential provider service to listen on")
 	rootCmd.AddCommand(serveCmd)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,15 +34,19 @@ var log = logging.GetLogger()
 func init() {
 	// Set default configuration values here
 	viper.SetTypeByDefaultValue(true)
+	viper.SetDefault("authentication_method", "challenge")
 	viper.SetDefault("aws.region", "us-east-1")
 	viper.SetDefault("feature_flags.consoleme_metadata", false)
 	viper.SetDefault("log_file", getDefaultLogFile())
 	viper.SetDefault("mtls_settings.old_cert_message", "mTLS certificate is too old, please refresh mtls certificate")
 	viper.SetDefault("server.http_timeout", 20)
-	viper.SetDefault("server.metadata_port", 9090)
-	viper.SetDefault("server.ecs_credential_provider_port", 9091)
+	viper.SetDefault("server.address", "127.0.0.1")
+	viper.SetDefault("server.port", 9091)
 	viper.SetDefault("service.command", "ecs_credential_provider")
 	viper.SetDefault("service.args", []string{})
+
+	// Set aliases for backward-compatibility
+	viper.RegisterAlias("server.ecs_credential_provider_port", "server.port")
 }
 
 func getDefaultLogFile() string {
@@ -147,6 +151,11 @@ func SetUser(user string) error {
 		return err
 	}
 	return nil
+}
+
+func MtlsEnabled() bool {
+	authMethod := viper.GetString("authentication_method")
+	return authMethod == "mtls"
 }
 
 var (

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -6,8 +6,8 @@ aws:
   region: us-east-1
 server:
   http_timeout: 20
-  metadata_port: 9090
-  ecs_credential_provider_port: 9091
+  address: 127.0.0.1
+  port: 9091
 service:
   command: ecs_credential_provider
   args:

--- a/httpAuth/mtls/mtls.go
+++ b/httpAuth/mtls/mtls.go
@@ -38,8 +38,23 @@ import (
 
 var log = logging.GetLogger()
 
+var tlsConfig *tls.Config
+
+func init() {
+	if config.MtlsEnabled() {
+		var err error
+		tlsConfig, err = getTLSConfig()
+		if err != nil {
+			log.Fatalf("could not initialize mtls: %v", err)
+		}
+	}
+}
+
 // getTLSConfig makes and returns a pointer to a tls.Config
 func getTLSConfig() (*tls.Config, error) {
+	if tlsConfig != nil {
+		return tlsConfig, nil
+	}
 	dirs, err := getTLSDirs()
 	if err != nil {
 		return nil, err
@@ -48,7 +63,7 @@ func getTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	tlsConfig, err := makeTLSConfig(certFile, keyFile, caFile, insecure)
+	tlsConfig, err = makeTLSConfig(certFile, keyFile, caFile, insecure)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -48,7 +48,7 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 	router.HandleFunc("/{path:.*}", CredentialServiceMiddleware(CustomHandler))
 
 	go func() {
-		log.Info("Starting weep on ", listenAddr)
+		log.Info("starting weep on ", listenAddr)
 		srv := &http.Server{
 			ReadTimeout:       1 * time.Second,
 			WriteTimeout:      10 * time.Second,
@@ -64,6 +64,6 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 
 	// Check for interrupt signal and exit cleanly
 	<-shutdown
-	log.Print("Shutdown signal received, stopping server...")
+	log.Print("shutdown signal received, stopping server...")
 	return nil
 }

--- a/weep-demo.yaml
+++ b/weep-demo.yaml
@@ -4,6 +4,5 @@ consoleme_url: https://demo.consolemeoss.com
 mtls_settings:
   old_cert_message: mTLS certificate is too old, please refresh mtls certificate
 server:
-  ecs_credential_provider_port: 9091
+  port: 9091
   http_timeout: 20
-  metadata_port: 9090


### PR DESCRIPTION
- Fix FD leak by reusing TLS configuration across clients
- Update config key for server port, add server address to config
- Remove AWS credential provider retries so we can return a helpful error instead of the SDK timing out
- A bit of logging housekeeping