### PR TITLE
Add separate config for service flags

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -57,14 +57,22 @@ func (p *program) Start(s service.Service) error {
 }
 
 func (p *program) run() {
+	var err error
 	log.Info("starting weep service!")
 	exitCode := 0
+
+	flags := viper.GetStringSlice("service.args")
+	err = rootCmd.ParseFlags(flags)
+	if err != nil {
+		log.Errorf("could not parse flags: %v", err)
+	}
+
 	args := viper.GetStringSlice("service.args")
 	switch command := viper.GetString("service.command"); command {
 	case "ecs_credential_provider":
 		fallthrough
 	case "serve":
-		err := runWeepServer(nil, args)
+		err = runWeepServer(nil, args)
 		if err != nil {
 			log.Error(err)
 			exitCode = 1

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ func init() {
 	viper.SetDefault("server.port", 9091)
 	viper.SetDefault("service.command", "ecs_credential_provider")
 	viper.SetDefault("service.args", []string{})
+	viper.SetDefault("service.flags", []string{})
 
 	// Set aliases for backward-compatibility
 	viper.RegisterAlias("server.ecs_credential_provider_port", "server.port")

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -9,10 +9,12 @@ server:
   address: 127.0.0.1
   port: 9091
 service:
-  command: ecs_credential_provider
-  args:
+  command: serve
+  flags:  # Flags are CLI options
     - --log-level
     - debug
+  args:  # Args are command arguments. This configuration will start the metadata service with credentials for roleName
+    - roleName
 #challenge_settings: # (Optional) Username can be provided. If it is not provided, user will be prompted on first authentication attempt
 #  user: you@example.com
 mtls_settings: # only needed if authentication_method is mtls


### PR DESCRIPTION
Allow the service command to be configured with flags separated from args to avoid problems with flags being interpreted as args.