### PR TITLE
Fix default log dir, endpoint trailing slash tweak

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,9 +54,9 @@ func init() {
 func getDefaultLogFile() string {
 	switch os := runtime.GOOS; os {
 	case "darwin":
-		return filepath.Join("tmp", "weep.log")
+		return filepath.Join("/", "tmp", "weep.log")
 	case "linux":
-		return filepath.Join("tmp", "weep.log")
+		return filepath.Join("/", "tmp", "weep.log")
 	case "windows":
 		p, _ := filepath.Abs(filepath.FromSlash("/programdata/weep/weep.log"))
 		return p

--- a/server/credentialsHandler.go
+++ b/server/credentialsHandler.go
@@ -32,7 +32,7 @@ func RoleHandler(w http.ResponseWriter, r *http.Request) {
 		util.WriteError(w, "error", 500)
 		return
 	}
-	if _, err := w.Write([]byte(defaultRole.RoleName)); err != nil {
+	if _, err := w.Write([]byte(fmt.Sprintf("%s\n", defaultRole.RoleName))); err != nil {
 		log.Errorf("failed to write response: %v", err)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,8 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 		router.HandleFunc("/{version}/meta-data", CredentialServiceMiddleware(BaseHandler))
 		router.HandleFunc("/{version}/meta-data/", CredentialServiceMiddleware(BaseHandler))
 		router.HandleFunc("/{version}/meta-data/iam/info", CredentialServiceMiddleware(IamInfoHandler))
+		// There's an extra route here to support the lack of trailing slash without the redirect that StrictSlash(true) does
+		router.HandleFunc("/{version}/meta-data/iam/security-credentials", CredentialServiceMiddleware(RoleHandler))
 		router.HandleFunc("/{version}/meta-data/iam/security-credentials/", CredentialServiceMiddleware(RoleHandler))
 		router.HandleFunc("/{version}/meta-data/iam/security-credentials/{role}", CredentialServiceMiddleware(IMDSHandler))
 		router.HandleFunc("/{version}/dynamic/instance-identity/document", CredentialServiceMiddleware(InstanceIdentityDocumentHandler))


### PR DESCRIPTION
Weep was creating `tmp/weep.log` in its working dir, which is annoying and bad.

This PR also adds support for no trailing slash on the `/latest/meta-data/iam/security-credentials` endpoint to match the behavior of IMDS.