### PR TITLE
Move flags to root command for use by service

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", viper.GetString("log_file"), "log file path")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level (debug, info, warn)")
 	rootCmd.PersistentFlags().StringVarP(&region, "region", "r", viper.GetString("aws.region"), "AWS region")
+	rootCmd.PersistentFlags().StringVarP(&listenAddr, "listen-address", "a", viper.GetString("server.address"), "IP address for the ECS credential provider to listen on")
+	rootCmd.PersistentFlags().IntVarP(&listenPort, "port", "p", viper.GetInt("server.port"), "port for the ECS credential provider service to listen on")
 }
 
 func Run(initFunctions ...func()) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,15 +17,11 @@
 package cmd
 
 import (
-	"github.com/spf13/viper"
-
 	"github.com/netflix/weep/server"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	serveCmd.PersistentFlags().StringVarP(&listenAddr, "listen-address", "a", viper.GetString("server.address"), "IP address for the ECS credential provider to listen on")
-	serveCmd.PersistentFlags().IntVarP(&listenPort, "port", "p", viper.GetInt("server.port"), "port for the ECS credential provider service to listen on")
 	rootCmd.AddCommand(serveCmd)
 }
 


### PR DESCRIPTION
Because we only parse flags for the root command when running Weep as a system service, `listenAddr` and `listenPort` are not able to be configured via CLI flags when calling `weep service run`.