### PR TITLE
Allow URL override for `open` links

### DIFF
--- a/creds/consoleme.go
+++ b/creds/consoleme.go
@@ -207,7 +207,16 @@ func (c *Client) GetResourceURL(arn string) (string, error) {
 	if err := json.Unmarshal(document, &responseParsed); err != nil {
 		return "", errors.Wrap(err, "failed to unmarshal JSON")
 	}
-	return viper.GetString("consoleme_url") + responseParsed.Data["url"], nil
+	return baseWebURL() + responseParsed.Data["url"], nil
+}
+
+// baseWebURL allows the ConsoleMe URL to be overridden for cases where the API
+// and UI are accessed via different URLs
+func baseWebURL() string {
+	if override := viper.GetString("consoleme_open_url_override"); override != "" {
+		return override
+	}
+	return viper.GetString("consoleme_url")
 }
 
 func parseWebError(rawErrorResponse []byte) error {


### PR DESCRIPTION
In cases where ConsoleMe is configured to use mutual TLS, the API and web interface may be served from different URLs. This PR adds the ability to override the `consoleme_url` config entry with `consoleme_open_url_override` for the purpose of generating URLs for the `open` command.