### PR TITLE
Bind CLI flags to config keys

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,15 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", viper.GetString("log_file"), "log file path")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level (debug, info, warn)")
 	rootCmd.PersistentFlags().StringVarP(&region, "region", "r", viper.GetString("aws.region"), "AWS region")
+	if err := viper.BindPFlag("log_level", rootCmd.PersistentFlags().Lookup("log-level")); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlag("log_file", rootCmd.PersistentFlags().Lookup("log-file")); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlag("log_format", rootCmd.PersistentFlags().Lookup("log-format")); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func Run(initFunctions ...func()) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -26,6 +26,12 @@ import (
 func init() {
 	serveCmd.PersistentFlags().StringVarP(&listenAddr, "listen-address", "a", viper.GetString("server.address"), "IP address for the ECS credential provider to listen on")
 	serveCmd.PersistentFlags().IntVarP(&listenPort, "port", "p", viper.GetInt("server.port"), "port for the ECS credential provider service to listen on")
+	if err := viper.BindPFlag("server.address", serveCmd.PersistentFlags().Lookup("listen-address")); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlag("server.port", serveCmd.PersistentFlags().Lookup("port")); err != nil {
+		log.Fatal(err)
+	}
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -42,5 +48,7 @@ func runWeepServer(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		role = args[0]
 	}
-	return server.Run(listenAddr, listenPort, role, region, shutdown)
+	address := viper.GetString("server.address")
+	port := viper.GetInt("server.port")
+	return server.Run(address, port, role, region, shutdown)
 }

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -2,6 +2,7 @@ consoleme_url: https://path_to_consoleme:port
 authentication_method: mtls # challenge or mtls
 log_level: info
 log_file: /path/to/log/file
+log_format: tty
 aws:
   region: us-east-1
 server:


### PR DESCRIPTION
This PR changes how Weep handles CLI flags that can also be set in the configuration file to fix an issue where configuration settings are not correctly handled when running Weep as a system service.