### PR TITLE
fix: Create directory for file and credential_process commands

### DIFF
--- a/cmd/credential_process.go
+++ b/cmd/credential_process.go
@@ -51,11 +51,17 @@ func writeConfigFile(roles []string, destination string) error {
 	ini.PrettyEqual = true
 
 	if util.FileExists(destination) {
+		// There's an existing config file, so we'll load it in and update the existing contents
 		configINI, err = ini.Load(destination)
 		if err != nil {
 			return err
 		}
 	} else {
+		// Config file doesn't exist yet. Create it with the same perms as awscli
+		err = util.CreateFile(destination, 0700, 0600)
+		if err != nil {
+			return err
+		}
 		configINI = ini.Empty()
 	}
 

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -161,11 +161,17 @@ func writeCredentialsFile(credentials *creds.AwsCredentials, profile, filename s
 	ini.PrettyEqual = true
 
 	if util.FileExists(filename) {
+		// There's an existing credentials file, so we'll load it in and update the existing contents
 		credentialsINI, err = ini.Load(filename)
 		if err != nil {
 			return err
 		}
 	} else {
+		// Credentials file doesn't exist yet. Create it with the same perms as awscli
+		err = util.CreateFile(filename, 0700, 0600)
+		if err != nil {
+			return err
+		}
 		credentialsINI = ini.Empty()
 	}
 
@@ -186,5 +192,5 @@ func writeCredentialsFile(credentials *creds.AwsCredentials, profile, filename s
 		return err
 	}
 
-	return nil
+	return err
 }


### PR DESCRIPTION
Automatically create directory/directories when writing files with the `file` and `credential_process` commands, a la `mkdir -p`. This PR also changes the file permissions to more closely match those that are set by awscli.

Fixes #70 