### PR TITLE
Fix runtime panic due to missing argument

### DIFF
--- a/cmd/credential_process.go
+++ b/cmd/credential_process.go
@@ -101,6 +101,9 @@ func runCredentialProcess(cmd *cobra.Command, args []string) error {
 	if generate {
 		return generateCredentialProcessConfig(destination)
 	}
+	if len(args) == 0 {
+		return fmt.Errorf("role_name not provided")
+	}
 	role := args[0]
 	credentials, err := creds.GetCredentials(role, noIpRestrict, assumeRole, "")
 	if err != nil {


### PR DESCRIPTION
Fix a minor missing check that causes a runtime panic, instead of displaying an appropriate error.
Command: `weep credential_process`
Previous output:
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/netflix/weep/cmd.runCredentialProcess(0x1c5acc0, 0x1c93cf0, 0x0, 0x0, 0x0, 0x0)
        /Users/Jay/go/src/github.com/netflix/weep/cmd/credential_process.go:107 +0x125
github.com/spf13/cobra.(*Command).execute(0x1c5acc0, 0x1c93cf0, 0x0, 0x0, 0x1c5acc0, 0x1c93cf0)
        /Users/Jay/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x1c58c40, 0xc00029ff28, 0x3, 0x3)
        /Users/Jay/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/Jay/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/netflix/weep/cmd.Execute(0xffffffff, 0xc000180058)
        /Users/Jay/go/src/github.com/netflix/weep/cmd/root.go:80 +0x115
main.main()
        /Users/Jay/go/src/github.com/netflix/weep/main.go:26 +0x25
exit status 2
```

Output after code change:
```
Error: role_name not provided
Usage:
  weep credential_process [role_name] [flags]

Flags:
  -g, --generate        generate ~/.aws/config with credential process config
  -h, --help            help for credential_process
  -o, --output string   output file for AWS config (default "/Users/Jay/.aws/config")

Global Flags:
  -A, --assume-role strings   one or more roles to assume after retrieving credentials
  -c, --config string         config file (default is $HOME/.weep.yaml)
      --log-file string       log file path (default "/tmp/weep.log")
      --log-format string     log format (json or tty)
      --log-level string      log level (debug, info, warn)
  -n, --no-ip                 remove IP restrictions
  -r, --region string         AWS region (default "us-east-1")

exit status 1
```