### PR TITLE
Address #73

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 
 	"github.com/netflix/weep/creds"
@@ -62,6 +63,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	cmd.SetOut(os.Stdout)
 	cmd.Print(roles)
 	return nil
 }


### PR DESCRIPTION
Address #73 by setting output to for the `Print` command before calling the `Print` command. Currently, since we don't set the output, it goes to stderr by default. This will explicitly set the output to go to stdout.