### PR TITLE
Reachability test

### DIFF
--- a/pkg/reachability/channels.go
+++ b/pkg/reachability/channels.go
@@ -1,0 +1,41 @@
+package reachability
+
+import (
+	"time"
+)
+
+const maxWaitTimeSeconds = 3
+
+var c chan struct{}
+
+func init() {
+	c = make(chan struct{})
+}
+
+// Notify will signal the reachability package that some reachability test
+// were received by this Weep instance
+func Notify() {
+	// Only sends when there is already some receiver waiting. Never blocks.
+	select {
+	case c <- struct{}{}:
+	default:
+	}
+}
+
+func wait() bool {
+	timeout := make(chan struct{})
+	go func() {
+		time.Sleep(maxWaitTimeSeconds * time.Second)
+		timeout <- struct{}{}
+	}()
+
+	select {
+	case <-c:
+		// Received a rechability test
+		return true
+	case <-timeout:
+		// Timed out, move on
+	}
+
+	return false
+}

--- a/pkg/reachability/request.go
+++ b/pkg/reachability/request.go
@@ -1,0 +1,37 @@
+package reachability
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/netflix/weep/pkg/logging"
+)
+
+// TestReachability sends a GET request to the address IMDS is expected to run, while checks
+// whether this test was received by this same Weep instance, otherwise logs a warning
+func TestReachability() {
+	go func() {
+		logging.Log.Debug("Doing a healthcheck request on 169.254.169.254")
+		resp, err := http.Get("http://169.254.169.254/healthcheck?reachability=1")
+
+		// A response can be successful but have being served by another process on the
+		// IMDS port/an actual IMDS. So we prefer relying on the reachability signal (which
+		// means this same process received a reachability test).
+
+		if err != nil {
+			logging.Log.WithField("err", err).Debug("Received an error from healthcheck route")
+		} else {
+			logging.Log.WithField("status", resp.StatusCode).Debug("Received a response from healthcheck route")
+		}
+	}()
+
+	received := wait()
+	if received {
+		logging.Log.Info("Reachability test was successful")
+	} else {
+		logging.Log.Warningf(
+			"Reachability test was unsuccessful. Looks like we aren't being served in 169.254.169.254. Did you `%s setup`?",
+			os.Args[0],
+		)
+	}
+}

--- a/pkg/server/healthcheckHandler.go
+++ b/pkg/server/healthcheckHandler.go
@@ -3,8 +3,10 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/netflix/weep/pkg/logging"
+	"github.com/netflix/weep/pkg/reachability"
 
 	"github.com/netflix/weep/pkg/health"
 )
@@ -22,6 +24,12 @@ func HealthcheckHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		status = http.StatusInternalServerError
 	}
+
+	reachabilityFlag := r.URL.Query().Get("reachability")
+	if b, err := strconv.ParseBool(reachabilityFlag); err == nil && b {
+		reachability.Notify()
+	}
+
 	resp := healthcheckResponse{
 		Status:  status,
 		Message: reason,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/netflix/weep/pkg/cache"
+	"github.com/netflix/weep/pkg/creds"
 	"github.com/netflix/weep/pkg/logging"
 	"github.com/netflix/weep/pkg/reachability"
 


### PR DESCRIPTION
This PR proposes a reachability test previously described on issue #74

Adds a package with the capability of attempting to reach the IMDS serve, while also determining whether that Weep instance has received this test on the other side of the wire

Uses that package on `weep serve` and on the healthcheck route.

Demo:
![weep-serve](https://user-images.githubusercontent.com/4237373/135649852-9e3ded6c-dae2-4cd8-9ca7-310362417326.gif)

