### PR TITLE
Remove calls to Fatal log functions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -19,8 +19,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/netflix/weep/pkg/logging"
-
 	"github.com/spf13/cobra"
 )
 
@@ -49,10 +47,8 @@ MacOS:
 
   $ weep completion bash > /usr/local/etc/bash_completion.d/weep
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
-			logging.Log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Root().GenBashCompletion(os.Stdout)
 	},
 }
 
@@ -72,10 +68,8 @@ $ weep completion zsh > "${fpath[1]}/_weep"
 
 You will need to start a new shell for this setup to take effect.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Root().GenZshCompletion(os.Stdout); err != nil {
-			logging.Log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Root().GenZshCompletion(os.Stdout)
 	},
 }
 
@@ -90,10 +84,8 @@ To load completions for each session, execute once:
 
 $ weep completion fish > ~/.config/fish/completions/weep.fish
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Root().GenFishCompletion(os.Stdout, true); err != nil {
-			logging.Log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Root().GenFishCompletion(os.Stdout, true)
 	},
 }
 
@@ -133,10 +125,8 @@ PS> weep completion powershell > weep.ps1
 
 You will need to start a new shell for this setup to take effect.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Root().GenPowerShellCompletion(os.Stdout); err != nil {
-			logging.Log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Root().GenPowerShellCompletion(os.Stdout)
 	},
 }
 

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"github.com/netflix/weep/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -27,11 +26,8 @@ var docCommand = &cobra.Command{
 	Short:  docsShortHelp,
 	Long:   docsLongHelp,
 	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := doc.GenMarkdownTree(rootCmd, "./docs/")
-		if err != nil {
-			logging.Log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doc.GenMarkdownTree(rootCmd, "./docs/")
 	},
 }
 

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -109,7 +109,8 @@ func fileRefresher(role, profile, filename string, noIpRestrict bool, assumeRole
 func getDefaultCredentialsFile() string {
 	home, err := homedir.Dir()
 	if err != nil {
-		logging.Log.Fatal("couldn't get default directory")
+		logging.Log.Error("couldn't get home directory")
+		return ""
 	}
 	return path.Join(home, ".aws", "credentials")
 }
@@ -117,7 +118,8 @@ func getDefaultCredentialsFile() string {
 func getDefaultAwsConfigFile() string {
 	home, err := homedir.Dir()
 	if err != nil {
-		logging.Log.Fatal("couldn't get default directory")
+		logging.Log.Error("couldn't get home directory")
+		return ""
 	}
 	return path.Join(home, ".aws", "config")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,13 +56,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level (debug, info, warn)")
 	rootCmd.PersistentFlags().StringVarP(&region, "region", "r", viper.GetString("aws.region"), "AWS region")
 	if err := viper.BindPFlag("log_level", rootCmd.PersistentFlags().Lookup("log-level")); err != nil {
-		logging.Log.Fatal(err)
+		logging.Log.Error(err)
 	}
 	if err := viper.BindPFlag("log_file", rootCmd.PersistentFlags().Lookup("log-file")); err != nil {
-		logging.Log.Fatal(err)
+		logging.Log.Error(err)
 	}
 	if err := viper.BindPFlag("log_format", rootCmd.PersistentFlags().Lookup("log-format")); err != nil {
-		logging.Log.Fatal(err)
+		logging.Log.Error(err)
 	}
 }
 
@@ -85,7 +85,7 @@ func Execute() error {
 
 func initConfig() {
 	if err := config.InitConfig(cfgFile); err != nil {
-		logging.Log.Fatalf("failed to initialize config: %v", err)
+		logging.Log.Errorf("failed to initialize config: %v", err)
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -28,10 +28,10 @@ func init() {
 	serveCmd.PersistentFlags().StringVarP(&listenAddr, "listen-address", "a", viper.GetString("server.address"), "IP address for the ECS credential provider to listen on")
 	serveCmd.PersistentFlags().IntVarP(&listenPort, "port", "p", viper.GetInt("server.port"), "port for the ECS credential provider service to listen on")
 	if err := viper.BindPFlag("server.address", serveCmd.PersistentFlags().Lookup("listen-address")); err != nil {
-		logging.Log.Fatal(err)
+		logging.Log.Error(err)
 	}
 	if err := viper.BindPFlag("server.port", serveCmd.PersistentFlags().Lookup("port")); err != nil {
-		logging.Log.Fatal(err)
+		logging.Log.Error(err)
 	}
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -32,7 +32,10 @@ var weepServiceControl = &cobra.Command{
 }
 
 func runWeepServiceControl(cmd *cobra.Command, args []string) error {
-	initService()
+	err := initService()
+	if err != nil {
+		return err
+	}
 	if len(args[0]) > 0 {
 		// hijack a run command and run the service
 		if args[0] == "run" {
@@ -99,7 +102,7 @@ func (p *program) Stop(s service.Service) error {
 	return nil
 }
 
-func initService() {
+func initService() error {
 	var err error
 
 	svcProgram = &program{}
@@ -120,13 +123,13 @@ func initService() {
 
 	weepService, err = service.New(svcProgram, svcConfig)
 	if err != nil {
-		logging.Log.Fatal(err)
+		return err
 	}
 
 	errs := make(chan error, 5)
 	svcLogger, err = weepService.Logger(errs)
 	if err != nil {
-		logging.Log.Fatal(err)
+		return err
 	}
 
 	go func() {
@@ -137,4 +140,5 @@ func initService() {
 			}
 		}
 	}()
+	return nil
 }

--- a/pkg/httpAuth/mtls/certificate.go
+++ b/pkg/httpAuth/mtls/certificate.go
@@ -131,7 +131,7 @@ func (wc *wrappedCertificate) autoRefresh() {
 	for _, file := range []string{wc.certFile, wc.keyFile} {
 		err = watcher.Add(file)
 		if err != nil {
-			logging.Log.Fatal(err)
+			logging.Log.Error(err)
 		}
 	}
 

--- a/pkg/httpAuth/mtls/mtls.go
+++ b/pkg/httpAuth/mtls/mtls.go
@@ -44,7 +44,8 @@ func init() {
 		var err error
 		tlsConfig, err = getTLSConfig()
 		if err != nil {
-			logging.Log.Fatalf("could not initialize mtls: %v", err)
+			logging.Log.Errorf("could not initialize mtls: %v", err)
+			tlsConfig = &tls.Config{}
 		}
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,12 +69,13 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		logging.Log.Fatalf("listen failed: %v", err)
+		logging.Log.Errorf("listen failed: %v", err)
+		return err
 	}
 
 	go func() {
 		if err := srv.Serve(ln); err != nil {
-			logging.Log.Fatalf("server failed: %v", err)
+			logging.Log.Errorf("server failed: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
We've been unnecessarily using the `Fatal()` and `Fatalf()` log functions for things that don't actually need to be fatal. This switches a lot of those to `Error()` and `Errorf()`, respectively, or returns errors to be handled at a higher level where possible.