### PR TITLE
Restart Windows service on failure

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -124,6 +124,10 @@ func initService() error {
 		DisplayName: "Weep",
 		Description: "The ConsoleMe CLI",
 		Arguments:   args,
+		Option: service.KeyValue{
+			"OnFailure":              "restart", // Windows only
+			"OnFailureDelayDuration": "1m",      // Windows only
+		},
 	}
 
 	weepService, err = service.New(svcProgram, svcConfig)


### PR DESCRIPTION
This PR adds some extra options to the service installation that will configure the Windows service to restart on failures.