### PR TITLE
Allow extra config file

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,9 +17,10 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"strings"
+
+	"github.com/spf13/viper"
 
 	"github.com/netflix/weep/pkg/logging"
 
@@ -35,7 +36,6 @@ func init() {
 	listCmd.PersistentFlags().BoolVar(&showAll, "all", true, "show user profiles as well as instance profiles")
 	listCmd.PersistentFlags().BoolVar(&showInstanceProfilesOnly, "instance", false, "show only instance roles")
 	listCmd.PersistentFlags().BoolVar(&showConfiguredProfilesOnly, "profiles", false, "show only configured roles")
-	listCmd.PersistentFlags().StringToStringVar(&awsProfiles, "aws-profiles", nil, "")
 	rootCmd.AddCommand(listCmd)
 }
 
@@ -58,10 +58,8 @@ func roleList() (string, error) {
 	var rolesData [][]string
 
 	awsProfilesARNs := make(map[string]bool)
+	awsProfiles := viper.GetStringMapString("aws-profiles")
 	if showConfiguredProfilesOnly {
-		if awsProfiles == nil {
-			return "", fmt.Errorf("cannot filter by aws-profiles, as no aws-profiles were found")
-		}
 		for _, arn := range awsProfiles {
 			awsProfilesARNs[arn] = true
 		}

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -22,12 +22,12 @@ var (
 	accountFilter              string
 	assumeRole                 []string
 	autoRefresh                bool
-	awsProfiles                map[string]string
 	cfgFile                    string
 	destination                string
 	destinationConfig          string
 	done                       chan int
 	extendedInfo               bool
+	extraConfigFile            string
 	force                      bool
 	generate                   bool
 	infoDecode                 bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -169,6 +170,20 @@ func BaseWebURL() string {
 		return override
 	}
 	return viper.GetString("consoleme_url")
+}
+
+func MergeExtraConfigFile(extraConfigFile string) error {
+	f, err := os.Open(extraConfigFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err = viper.MergeConfig(f); err != nil {
+		return errors.Wrap(err, "could not merge extra config")
+	}
+
+	return nil
 }
 
 var (


### PR DESCRIPTION
Allows the user to specify an extra config file at runtime by using the argument `--extra-config-file /path/to/file.yaml`