### PR TITLE
Replace `logging.Log.Error()` with `logging.LogError()`

### DIFF
--- a/pkg/creds/refreshable.go
+++ b/pkg/creds/refreshable.go
@@ -66,7 +66,7 @@ func (rp *RefreshableProvider) AutoRefresh() {
 		case _ = <-ticker.C:
 			_, err := rp.checkAndRefresh(10)
 			if err != nil {
-				logging.Log.Error(err.Error())
+				logging.LogError(err, "failed to refresh credentials")
 			}
 		}
 	}

--- a/pkg/httpAuth/mtls/certificate.go
+++ b/pkg/httpAuth/mtls/certificate.go
@@ -129,7 +129,7 @@ func (wc *wrappedCertificate) autoRefresh() {
 	for _, file := range []string{wc.certFile, wc.keyFile} {
 		err = watcher.Add(file)
 		if err != nil {
-			logging.Log.Error(err)
+			logging.LogError(err, "failed to add file to watcher")
 		}
 	}
 

--- a/pkg/httpAuth/mtls/mtls.go
+++ b/pkg/httpAuth/mtls/mtls.go
@@ -72,7 +72,7 @@ func getTLSConfig() (*tls.Config, error) {
 
 func makeTLSConfig(certFile, keyFile, caFile string, insecure bool) (*tls.Config, error) {
 	if certFile == "" || keyFile == "" || caFile == "" {
-		logging.Log.Error("MTLS cert, key, or CA file not defined in configuration")
+		logging.LogError(fmt.Errorf("mTLS cert, key, or CA file not defined in configuration"), "mTLS could not be initialized")
 		return nil, MissingTLSConfigError
 	}
 	caCert, _ := ioutil.ReadFile(caFile)

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -97,5 +97,5 @@ func RegisterLogger(l *logrus.Entry) {
 
 // LogError is a helper function that allows for errors to be logged easily
 func LogError(err error, message string) {
-	Log.WithFields(logrus.Fields{"error": err.Error()}).Warnln(message)
+	Log.WithError(err).Errorln(message)
 }

--- a/pkg/server/ecsCredentialsHandler.go
+++ b/pkg/server/ecsCredentialsHandler.go
@@ -58,13 +58,13 @@ func getCredentialHandler(region string) func(http.ResponseWriter, *http.Request
 	return func(w http.ResponseWriter, r *http.Request) {
 		var client, err = creds.GetClient(region)
 		if err != nil {
-			logging.Log.Error(err)
+			logging.LogError(err, "error getting credentials")
 			util.WriteError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		assume, err := parseAssumeRoleQuery(r)
 		if err != nil {
-			logging.Log.Error(err)
+			logging.LogError(err, "error parsing assume role query")
 			util.WriteError(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,13 +70,13 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		logging.Log.Errorf("listen failed: %v", err)
+		logging.LogError(err, "listen failed")
 		return err
 	}
 
 	go func() {
 		if err := srv.Serve(ln); err != nil {
-			logging.Log.Errorf("server failed: %v", err)
+			logging.LogError(err, "server failed")
 		}
 	}()
 


### PR DESCRIPTION
This PR attaches errors to logs in a more consistent way so they're handled well by custom loggers.