### PR TITLE
Add support for custom HTTP client & preflight

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -160,7 +160,7 @@ func SetUser(user string) error {
 
 func MtlsEnabled() bool {
 	authMethod := viper.GetString("authentication_method")
-	return authMethod == "mtls"
+	return authMethod == "mtls" && viper.GetBool("mtls_settings.enabled")
 }
 
 // BaseWebURL allows the ConsoleMe URL to be overridden for cases where the API

--- a/pkg/creds/consoleme.go
+++ b/pkg/creds/consoleme.go
@@ -48,6 +48,8 @@ import (
 var clientVersion = fmt.Sprintf("%s", metadata.Version)
 
 var userAgent = "weep/" + clientVersion + " Go-http-client/1.1"
+var clientFactoryOverride ClientFactory
+var preflightFunctions = make([]RequestPreflight, 0)
 
 type Account struct {
 }
@@ -67,12 +69,34 @@ type Client struct {
 	Region string
 }
 
+type ClientFactory func() (*http.Client, error)
+
+func RegisterClientFactory(factory ClientFactory) {
+	clientFactoryOverride = factory
+}
+
+type RequestPreflight func(req *http.Request) error
+
+func RegisterRequestPreflight(preflight RequestPreflight) {
+	preflightFunctions = append(preflightFunctions, preflight)
+}
+
 // GetClient creates an authenticated ConsoleMe client
 func GetClient(region string) (*Client, error) {
 	var client *Client
 	consoleMeUrl := viper.GetString("consoleme_url")
 	authenticationMethod := viper.GetString("authentication_method")
 
+	if clientFactoryOverride != nil {
+		customClient, err := clientFactoryOverride()
+		if err != nil {
+			return client, err
+		}
+		client, err = NewClient(consoleMeUrl, "", customClient)
+		if err != nil {
+			return client, err
+		}
+	}
 	if authenticationMethod == "mtls" {
 		mtlsClient, err := mtls.NewHTTPClient()
 		if err != nil {
@@ -122,6 +146,18 @@ func NewClient(hostname string, region string, httpc *http.Client) (*Client, err
 	return c, nil
 }
 
+func runPreflightFunctions(req *http.Request) error {
+	var err error
+	if preflightFunctions != nil {
+		for _, preflight := range preflightFunctions {
+			if err = preflight(req); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (c *Client) buildRequest(method string, resource string, body io.Reader, apiPrefix string) (*http.Request, error) {
 	urlStr := c.Host + apiPrefix + resource
 	req, err := http.NewRequest(method, urlStr, body)
@@ -130,6 +166,10 @@ func (c *Client) buildRequest(method string, resource string, body io.Reader, ap
 	}
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Add("Content-Type", "application/json")
+	err = runPreflightFunctions(req)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }

--- a/pkg/creds/consoleme.go
+++ b/pkg/creds/consoleme.go
@@ -98,8 +98,7 @@ func GetClient(region string) (*Client, error) {
 		if err != nil {
 			return client, err
 		}
-	}
-	if authenticationMethod == "mtls" {
+	} else if authenticationMethod == "mtls" {
 		mtlsClient, err := mtls.NewHTTPClient()
 		if err != nil {
 			return client, err

--- a/pkg/creds/consoleme.go
+++ b/pkg/creds/consoleme.go
@@ -51,9 +51,6 @@ var userAgent = "weep/" + clientVersion + " Go-http-client/1.1"
 var clientFactoryOverride ClientFactory
 var preflightFunctions = make([]RequestPreflight, 0)
 
-type Account struct {
-}
-
 // HTTPClient is the interface we expect HTTP clients to implement.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -71,12 +68,17 @@ type Client struct {
 
 type ClientFactory func() (*http.Client, error)
 
+// RegisterClientFactory overrides Weep's standard config-based ConsoleMe client
+// creation with a ClientFactory. This function will be called during the creation
+// of all ConsoleMe clients.
 func RegisterClientFactory(factory ClientFactory) {
 	clientFactoryOverride = factory
 }
 
 type RequestPreflight func(req *http.Request) error
 
+// RegisterRequestPreflight adds a RequestPreflight function which will be called in the
+// order of registration during the creation of a ConsoleMe request.
 func RegisterRequestPreflight(preflight RequestPreflight) {
 	preflightFunctions = append(preflightFunctions, preflight)
 }


### PR DESCRIPTION
This PR allows for customizing the ConsoleMe HTTP client creation and request building workflows when using Weep as a library.