### PR TITLE
Refactor HTTP client creation to be more generic

### DIFF
--- a/cmd/credential_process.go
+++ b/cmd/credential_process.go
@@ -89,7 +89,7 @@ func generateCredentialProcessConfig(destination string) error {
 	if destination == "" {
 		return fmt.Errorf("no destination provided")
 	}
-	client, err := creds.GetClient(region)
+	client, err := creds.GetClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -197,7 +197,7 @@ func preInteractiveCheck(region string, client *creds.Client) (*creds.Client, er
 	// If a client was not provided, create one using the provided region
 	if client == nil {
 		var err error
-		client, err = creds.GetClient(region)
+		client, err = creds.GetClient()
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,7 +47,7 @@ var listCmd = &cobra.Command{
 }
 
 func roleList() (string, error) {
-	client, err := creds.GetClient(region)
+	client, err := creds.GetClient()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -53,7 +53,7 @@ func runOpen(cmd *cobra.Command, args []string) error {
 		return errors.New("Resource type sns and sqs require region in the arn")
 	}
 	var resourceURL string
-	client, err := creds.GetClient(region)
+	client, err := creds.GetClient()
 	if err != nil {
 		logging.LogError(err, "Error getting client")
 		return err

--- a/pkg/httpAuth/custom/custom.go
+++ b/pkg/httpAuth/custom/custom.go
@@ -1,0 +1,45 @@
+package custom
+
+import "net/http"
+
+var isOverridden bool
+var clientFactoryOverride ClientFactory
+var preflightFunctions = make([]RequestPreflight, 0)
+
+type ClientFactory func() (*http.Client, error)
+
+func UseCustom() bool {
+	return isOverridden
+}
+
+func NewHTTPClient() (*http.Client, error) {
+	return clientFactoryOverride()
+}
+
+// RegisterClientFactory overrides Weep's standard config-based ConsoleMe client
+// creation with a ClientFactory. This function will be called during the creation
+// of all ConsoleMe clients.
+func RegisterClientFactory(factory ClientFactory) {
+	clientFactoryOverride = factory
+	isOverridden = true
+}
+
+type RequestPreflight func(req *http.Request) error
+
+// RegisterRequestPreflight adds a RequestPreflight function which will be called in the
+// order of registration during the creation of a ConsoleMe request.
+func RegisterRequestPreflight(preflight RequestPreflight) {
+	preflightFunctions = append(preflightFunctions, preflight)
+}
+
+func RunPreflightFunctions(req *http.Request) error {
+	var err error
+	if preflightFunctions != nil {
+		for _, preflight := range preflightFunctions {
+			if err = preflight(req); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/httpAuth/httpAuth.go
+++ b/pkg/httpAuth/httpAuth.go
@@ -1,0 +1,28 @@
+package httpAuth
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/netflix/weep/pkg/httpAuth/challenge"
+	"github.com/netflix/weep/pkg/httpAuth/custom"
+	"github.com/netflix/weep/pkg/httpAuth/mtls"
+	"github.com/spf13/viper"
+)
+
+func GetAuthenticatedClient() (*http.Client, error) {
+	authenticationMethod := viper.GetString("authentication_method")
+	consoleMeUrl := viper.GetString("consoleme_url")
+	if custom.UseCustom() {
+		return custom.NewHTTPClient()
+	} else if authenticationMethod == "mtls" {
+		return mtls.NewHTTPClient()
+	} else if authenticationMethod == "challenge" {
+		err := challenge.RefreshChallenge()
+		if err != nil {
+			return nil, err
+		}
+		return challenge.NewHTTPClient(consoleMeUrl)
+	}
+	return nil, fmt.Errorf("Authentication method unsupported or not provided.")
+}

--- a/pkg/server/ecsCredentialsHandler.go
+++ b/pkg/server/ecsCredentialsHandler.go
@@ -56,7 +56,7 @@ func parseAssumeRoleQuery(r *http.Request) ([]string, error) {
 
 func getCredentialHandler(region string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var client, err = creds.GetClient(region)
+		var client, err = creds.GetClient()
 		if err != nil {
 			logging.Log.Error(err)
 			util.WriteError(w, err.Error(), http.StatusBadRequest)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,7 +31,7 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 
 	if isServingIMDS {
 		logging.Log.Infof("Configuring weep IMDS service for role %s", role)
-		client, err := creds.GetClient(region)
+		client, err := creds.GetClient()
 		if err != nil {
 			return err
 		}

--- a/pkg/swag/swag.go
+++ b/pkg/swag/swag.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/netflix/weep/pkg/httpAuth/mtls"
+	"github.com/netflix/weep/pkg/creds"
+
 	"github.com/spf13/viper"
 )
 
@@ -15,7 +16,11 @@ type SwagResponse struct {
 
 func getClient() (*http.Client, error) {
 	if viper.GetBool("swag.use_mtls") {
-		return mtls.NewHTTPClient()
+		consoleMeClient, err := creds.GetClient()
+		if err != nil {
+			return nil, err
+		}
+		return &consoleMeClient.Client, nil
 	}
 	return http.DefaultClient, nil
 }


### PR DESCRIPTION
A quick revision to #112. This PR moves more into the `httpAuth` package and adds the custom stuffs to `httpAuth.custom`.