### PR TITLE
Update macOS pf config to support metadata address and localhost simultaneously

### DIFF
--- a/extras/macos/etc/pf.conf
+++ b/extras/macos/etc/pf.conf
@@ -27,3 +27,4 @@ dummynet-anchor "com.apple/*"
 anchor "com.apple/*"
 load anchor "com.apple" from "/etc/pf.anchors/com.apple"
 load anchor "redirection" from "/etc/pf.anchors/redirection"  # added by weep
+pass on lo0 all  # added by weep


### PR DESCRIPTION
Currently, Weep's macOS configuration does not allow the metadata emulation service to be accessed via `localhost` and `169.254.169.254` simultaneously. This PR adds a line to `pf.conf` to make the service accessible from both addresses.