### PR TITLE
Use application/json as content type when returning credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: git://github.com/dnephin/pre-commit-golang
+- repo: https://github.com/dnephin/pre-commit-golang
   rev: master
   hooks:
     - id: go-fmt

--- a/pkg/server/baseHandler.go
+++ b/pkg/server/baseHandler.go
@@ -47,6 +47,7 @@ reservation-id
 security-groups
 services/`
 
+	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprint(w, baseMetadata)
 }
 
@@ -56,6 +57,7 @@ func BaseVersionHandler(w http.ResponseWriter, r *http.Request) {
 meta-data
 user-data`
 
+	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprintln(w, baseVersionPath)
 }
 

--- a/pkg/server/credentialsHandler.go
+++ b/pkg/server/credentialsHandler.go
@@ -33,6 +33,7 @@ func RoleHandler(w http.ResponseWriter, r *http.Request) {
 		util.WriteError(w, "error", 500)
 		return
 	}
+	w.Header().Set("Content-Type", "text/plain")
 	if _, err := w.Write([]byte(fmt.Sprintf("%s\n", defaultRole.RoleName))); err != nil {
 		logging.Log.Errorf("failed to write response: %v", err)
 	}

--- a/pkg/server/ecsCredentialsHandler.go
+++ b/pkg/server/ecsCredentialsHandler.go
@@ -94,6 +94,7 @@ func getCredentialHandler(region string) func(http.ResponseWriter, *http.Request
 			Token:           fmt.Sprintf("%s", cachedCredentials.SessionToken),
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(credentialResponse)
 		if err != nil {
 			logging.Log.Errorf("failed to write response: %v", err)

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -35,7 +35,7 @@ import (
 
 // InstanceMetadataMiddleware is a convenience wrapper that chains TokenMiddleware, BrowserFilterMiddleware, and AWSHeaderMiddleware
 func InstanceMetadataMiddleware(next http.HandlerFunc) http.HandlerFunc {
-	return TokenMiddleware(TaskMetadataMiddleware(next))
+	return BrowserFilterMiddleware(TokenMiddleware(AWSHeaderMiddleware(next)))
 }
 
 // TaskMetadataMiddleware is a convenience wrapper that chains BrowserFilterMiddleware and AWSHeaderMiddleware
@@ -75,7 +75,6 @@ func AWSHeaderMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("ETag", strconv.FormatInt(rand.Int63n(10000000000), 10))
 		w.Header().Set("Last-Modified", time.Now().UTC().Format("2006-01-02T15:04:05Z")) // TODO: set this to cred refresh time
 		w.Header().Set("Server", "EC2ws")
-		w.Header().Set("Content-Type", "text/plain")
 
 		ua := r.Header.Get("User-Agent")
 		metadataVersion := 1

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -119,7 +119,7 @@ func TestAWSHeaderMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	t.Logf("test case: %s", description)
-	bfmHandler := InstanceMetadataMiddleware(nextHandler)
+	bfmHandler := AWSHeaderMiddleware(nextHandler)
 	req := httptest.NewRequest("GET", "http://localhost", nil)
 	rec := httptest.NewRecorder()
 	bfmHandler.ServeHTTP(rec, req)
@@ -134,9 +134,6 @@ func TestAWSHeaderMiddleware(t *testing.T) {
 	}
 	if server := rec.Header().Get("Server"); server != "EC2ws" {
 		t.Errorf("%s failed: got Server header %s, expected %s", description, server, "EC2ws")
-	}
-	if contentType := rec.Header().Get("Content-Type"); contentType != "text/plain" {
-		t.Errorf("%s failed: got Content-Type header %s, expected %s", description, contentType, "text/plain")
 	}
 }
 
@@ -167,9 +164,21 @@ func TestCredentialServiceMiddleware(t *testing.T) {
 			if server := rec.Header().Get("Server"); server != "EC2ws" {
 				t.Errorf("%s failed: got Server header %s, expected %s", tc.Description, server, "EC2ws")
 			}
-			if contentType := rec.Header().Get("Content-Type"); contentType != "text/plain" {
-				t.Errorf("%s failed: got Content-Type header %s, expected %s", tc.Description, contentType, "text/plain")
-			}
 		}
+	}
+}
+
+func TestTokenMiddleware(t *testing.T) {
+	description := "aws token middleware"
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	t.Logf("test case: %s", description)
+	bfmHandler := TokenMiddleware(nextHandler)
+	req := httptest.NewRequest("GET", "http://localhost", nil)
+	rec := httptest.NewRecorder()
+	bfmHandler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("%s failed: got status %d, expected %d", description, rec.Code, http.StatusOK)
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -125,6 +125,7 @@ func CreateFile(filename string, directoryPerm, filePerm fs.FileMode) error {
 // The error is written as plaintext so AWS SDKs will display it inline with an error message.
 func WriteError(w http.ResponseWriter, message string, status int) {
 	logging.Log.Debugf("writing HTTP error response: %s", message)
+	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(status)
 	_, err := w.Write([]byte(message))
 	if err != nil {


### PR DESCRIPTION
The credentials are returned as a JSON object so update the content type
to match instead of text/plain.