### PR TITLE
Fix binary path for macOS package build

### DIFF
--- a/build/build_package.sh
+++ b/build/build_package.sh
@@ -137,8 +137,8 @@ function cleanup() {
 }
 
 combine_binaries "$BIN_DIR/weep-universal" \
-  dist/bin/darwin_amd64/weep \
-  dist/bin/darwin_arm64/weep
+  dist/weep_darwin_amd64/weep \
+  dist/weep_darwin_arm64/weep
 sign_binary "$BIN_DIR/weep-universal"
 prep_package
 build_package


### PR DESCRIPTION
It seems that GoReleaser changed the output path for built binaries. This PR fixes the macOS packaging script based on the change.