### PR TITLE
Add optional "account_name-role_name" profile name generation instead of ARNs

### DIFF
--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -40,6 +40,7 @@ var (
 	noIpRestrict               bool
 	noOpen                     bool
 	profileName                string
+	prettyPrint                bool
 	region                     string
 	roleRefreshARN             string
 	shellInfo                  string

--- a/docs/weep_credential_process.md
+++ b/docs/weep_credential_process.md
@@ -9,16 +9,23 @@ weep credential_process [role_name] [flags]
 ### Options
 
 ```
-  -h, --help    help for credential_process
-  -n, --no-ip   remove IP restrictions
+  -h, --help                help for credential_process
+  -g, --generate            generate ~/.aws/config with credential process config
+  -o, --output string       output file for AWS config (default "~/.aws/config")
+  -p, --pretty              when combined with --generate/-g, use 'account_name-role_name' format for generated profiles instead of arn
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Add a new flag `--pretty` to be used w/ `weep credential_process --generate` to output profiles in `~/.aws/config` in the "account_name-role_name" format instead of profiles named after the role ARNs, while maintaining existing flow for backwards compatibility. 