### PR TITLE
Fix assumeRole parameter passing

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -53,5 +53,5 @@ func runWeepServer(cmd *cobra.Command, args []string) error {
 	address := viper.GetString("server.address")
 	port := viper.GetInt("server.port")
 	logging.Log.WithFields(logrus.Fields{"role": role}).Infoln("Running serve")
-	return server.Run(address, port, role, region, shutdown)
+	return server.Run(address, port, role, region, assumeRole, shutdown)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func Run(host string, port int, role, region string, shutdown chan os.Signal) error {
+func Run(host string, port int, role, region string, assumeChain []string, shutdown chan os.Signal) error {
 	ipaddress := net.ParseIP(host)
 
 	if ipaddress == nil {
@@ -35,7 +35,7 @@ func Run(host string, port int, role, region string, shutdown chan os.Signal) er
 		if err != nil {
 			return err
 		}
-		err = cache.GlobalCache.SetDefault(client, role, region, make([]string, 0))
+		err = cache.GlobalCache.SetDefault(client, role, region, assumeChain)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `-A` or `--assume-role` flag worked only when serving ECS Credential Provider endpoint.

This PRs fixes this by also passing the `assumeRole` arg down when starting up serving function in IMDS context.